### PR TITLE
Fix job data sanitization

### DIFF
--- a/reemployct_data_entry/entry.py
+++ b/reemployct_data_entry/entry.py
@@ -83,6 +83,8 @@ def main():
     ]
     target_week['table_jobs'] = wrangle.sanitize_dataframe(target_week['table_jobs'], JOB_DATA_TO_MATCH)
 
+    target_week['table_jobs'] = wrangle.us_only_addresses(target_week['table_jobs'])
+
     ############
     # Data Entry
     ############

--- a/reemployct_data_entry/entry.py
+++ b/reemployct_data_entry/entry.py
@@ -70,12 +70,22 @@ def main():
     table_jobs = wrangle.drop_bad_rows(table_jobs) # only for removing completed different rows that break dataframe consistency
     target_week = wrangle.isolate_week_from_day(table_jobs,  datetime.date.today() - datetime.timedelta(7)) # last week
 
+    if not wrangle.target_week_has_job_data(target_week):
+        return
+    
+    # isolate only job data that is required for satisfying ReEmployCT's work-search job entry requirements.
+    JOB_DATA_TO_MATCH = [
+        'Date of Work Search',
+        'Employer Name',
+        'Position Applied For',
+        'Employer Address',
+        'Website Address'
+    ]
+    target_week['table_jobs'] = wrangle.sanitize_dataframe(target_week['table_jobs'], JOB_DATA_TO_MATCH)
+
     ############
     # Data Entry
     ############
-
-    if not wrangle.target_week_has_job_data(target_week):
-        return
     
     driver = navigate_ReEmployCT.navigate(creds, target_week['table_jobs'])
     print(colorama.Fore.GREEN + "\nData entry finished. Quitting.\n" + colorama.Style.RESET_ALL)

--- a/reemployct_data_entry/entry_workSearch.py
+++ b/reemployct_data_entry/entry_workSearch.py
@@ -1,5 +1,4 @@
 import colorama
-import usaddress
 from selenium.webdriver.common.by import By
 
 from reemployct_data_entry.lib import webdriver as m_driver
@@ -59,8 +58,7 @@ def enterWorkSearch(driver, jobData_day):
 
   # create dict of US address components
   address = jobData_day['Employer Address']
-  address_parsed = usaddress.parse(address)
-  address_dict = wrangle.clean_usaddress_parse(address_parsed)
+  address_dict = wrangle.parse_us_address(address)
   address_dict['StateName'] = wrangle.state_abbrev_to_full_name(address_dict['StateName']) # Get state name or its abbreviation - MUST BE US ADDRESS
   address_line_1 = wrangle.build_address_from_cleaned_address_dict(address_dict)
 

--- a/reemployct_data_entry/lib/webdriver.py
+++ b/reemployct_data_entry/lib/webdriver.py
@@ -143,6 +143,7 @@ def msg_user_verify_entries(msg=None, color='green') -> None:
         msg = 'Review all entries to ensure correctness, then go to the next page.'
 
     msg_split = msg.split('\n')
+    msg_split = list(map(str.strip, msg_split)) # strip trailing whitespace
     max_str = max(msg_split, key=len)
     strLen = len(max_str)
 

--- a/reemployct_data_entry/lib/wrangle_job_data.py
+++ b/reemployct_data_entry/lib/wrangle_job_data.py
@@ -9,10 +9,48 @@ from . import stateDictionary as states
 from . import webdriver as m_driver
 
 
-def sanitize(driver, jobData):
+def sanitize_dataframe(df: pd.DataFrame, isolate_columns=[]) -> pd.DataFrame:
   '''
-  Sanitize and simplify user's excel job data.
-  Only return job data that is required for satisfying ReEmployCT's work-search job entry requirements.
+  Drop rows from pandas dataframe of bad data such as NaNs (includes empty data).
+  If columns names are included, drop all other columns except those specified. Strings must match names of columns.
+
+  Arguments:
+    df : 
+      Pandas dataframe
+    isolate_columns : str or [str]
+      Columns to isolate if specified.
+  '''
+
+  if(type(isolate_columns) == str):
+    isolate_columns = [isolate_columns]
+
+  # clean excel jobs rows and convert them to dicts
+  jobData_toCompare = []
+  for jobRow in range(len(df)):
+    jobRow = df.iloc[jobRow]
+    jobRow = jobRow.dropna()
+    date_timestamp_col = jobRow['Date of Work Search'] # save timestamp dtype because .strip() destroys it
+    jobRow = jobRow.str.strip() # strip leading and trailing whitespaces
+    jobRow['Date of Work Search'] = date_timestamp_col
+    jobRow = jobRow.drop('index')
+    jobRow = jobRow.to_dict()
+    jobData_toCompare.append(jobRow)
+
+  # isolate dict key values to only the most simple unqiue identifying info that needs to be compared
+  if(len(isolate_columns) > 0):
+    for jobRow in jobData_toCompare:
+      delete_dict_keys(jobRow, isolate_columns)
+
+  df = pd.DataFrame(jobData_toCompare)
+  df.dropna(inplace=True)
+  df.reset_index(drop=True, inplace=True)
+
+  return df
+
+
+def exclude_existing_entries(driver, jobData):
+  '''
+  Remove rows of job data that already exist as entries in ReEmployCT
   Should be executed on the work search page (where job data is entered) where there may be previous job entries present so they can be read.
   '''
 
@@ -60,32 +98,17 @@ def sanitize(driver, jobData):
   jobData_toCompare = []
   for jobRow in range(len(jobData)):
     jobRow = jobData.iloc[jobRow]
-    jobRow = jobRow.dropna()
-    date_timestamp_col = jobRow['Date of Work Search'] # save timestamp dtype because .strip() destroys it
-    jobRow = jobRow.str.strip() # strip leading and trailing whitespaces
-    jobRow['Date of Work Search'] = date_timestamp_col
-    jobRow = jobRow.drop('index')
     jobRow = jobRow.to_dict()
     jobData_toCompare.append(jobRow)
 
-  def deleteDictKeys(dictionary, keys):
-    dict_copy = dict(dictionary) # non reference copy
-    for key in dict_copy:
-      if(key not in keys):
-        del dictionary[key]
-    return dictionary
+  # get column names of jobData to isolate from entries_existing
+  JOB_DATA_TO_MATCH = []
+  for col in jobData.columns:
+    JOB_DATA_TO_MATCH.append(col)
 
-  # most simple unique indentifying info of a job application
-  JOB_DATA_TO_MATCH = [
-    'Date of Work Search',
-    'Employer Name',
-    'Position Applied For'
-  ]
   # isolate dict key values to only the most simple unqiue identifying info that needs to be compared
-  for jobRow in jobData_toCompare:
-    jobRow = deleteDictKeys(jobRow, JOB_DATA_TO_MATCH)
   for entry in entries_existing:
-    entry = deleteDictKeys(entry, JOB_DATA_TO_MATCH)
+    delete_dict_keys(entry, JOB_DATA_TO_MATCH)
 
   # filter out existing excel job data rows
   jobData_existing_indices = []
@@ -102,6 +125,15 @@ def sanitize(driver, jobData):
     'entries_min': entries_min,
     'entries_existing_n': entries_existing_n,
   }
+
+
+def delete_dict_keys(d, keys):
+  dict_copy = dict(d) # non reference copy
+  for key in dict_copy:
+    if(key not in keys):
+      del d[key]
+  return d
+
 
 def drop_bad_rows(df):
   '''

--- a/reemployct_data_entry/lib/wrangle_job_data.py
+++ b/reemployct_data_entry/lib/wrangle_job_data.py
@@ -182,6 +182,18 @@ def target_week_has_job_data(target_week):
   return True
 
 
+def parse_us_address(address: str) -> dict:
+  '''
+  Parse address elements from string into dict
+  Only works correctly for U.S. addresses
+  Can be used on any address and examined to see if it's a valid U.S. address (i.e. check if interpretation of U.S. state is valid)
+  This is a wrapper around usaddress.parse() to fix its bad output
+  '''
+  address = usaddress.parse(address)
+  address = clean_usaddress_parse(address)
+  return address
+
+
 ### US ADDRESSES
 
 def clean_usaddress_parse(address_parsed) -> dict:

--- a/reemployct_data_entry/navigate_ReEmployCT.py
+++ b/reemployct_data_entry/navigate_ReEmployCT.py
@@ -65,7 +65,7 @@ def navigate(creds, jobData):
   if(screenID == 'WC-800'): # Work Search Questionnaire page
     entry_workSearch.questionnaire(driver, CAPTCHA_TIMEOUT)
 
-    job_data_wrangled = wrangle.sanitize(driver, jobData)
+    job_data_wrangled = wrangle.exclude_existing_entries(driver, jobData)
     jobData = job_data_wrangled['jobData']
 
     # error if user doesn't have enough unique jobs to match minimum compliance 

--- a/tests/test_address_parsing.py
+++ b/tests/test_address_parsing.py
@@ -24,8 +24,7 @@ class Test_Address_Parsing(unittest.TestCase):
     }
 
     # create dict of US address components
-    address_parsed = usaddress.parse(ADDRESS_INPUT)
-    address_dict = wrangle.clean_usaddress_parse(address_parsed)
+    address_dict = wrangle.parse_us_address(ADDRESS_INPUT)
     address_dict['StateName'] = wrangle.state_abbrev_to_full_name(address_dict['StateName']) # Get state name or its abbreviation - MUST BE US ADDRESS
     address_line_1 = wrangle.build_address_from_cleaned_address_dict(address_dict)
 


### PR DESCRIPTION
Only job data from the user's Excel file that is completely valid, that is, isn't missing data and all data has been entered correctly, shall be selected to be entered into ReEmployCT. Only data that would cause errors from ReEmployCT is removed.